### PR TITLE
refactor: simplify tag page logic

### DIFF
--- a/src/pages/tags/[tag]/[...page].astro
+++ b/src/pages/tags/[tag]/[...page].astro
@@ -1,7 +1,7 @@
 ---
 // more info about this file: https://docs.astro.build/en/guides/routing/#dynamic-routes
 
-import { SITE, COLLECTION_NAMES_LIST } from "../../../alkaline.config";
+import { SITE, COLLECTION_NAMES_LIST } from "src/alkaline.config";
 import type { PaginateFunction } from "astro";
 import type { ContentEntryMap } from "astro:content";
 
@@ -33,10 +33,7 @@ export async function getStaticPaths({
   ];
 
   return uniqueTags.flatMap((tag) => {
-    if (tag === undefined) return [];
-    const filteredPosts = posts.filter(
-      (post) => post.data.tags && post.data.tags.includes(tag)
-    );
+    const filteredPosts = posts.filter((post) => post.data.tags?.includes(tag));
     return paginate(filteredPosts, {
       params: { tag },
       pageSize: SITE.postsPerPage,
@@ -45,9 +42,8 @@ export async function getStaticPaths({
   });
 }
 
-const { page } = Astro.props;
-const { tag } = Astro.params ?? {};
-const posts = page?.data ?? [];
+const { page, tag } = Astro.props;
+const posts = page.data;
 ---
 
 <Posts


### PR DESCRIPTION
Refactors the `[...page].astro` file for tag-based post filtering to be more concise and readable.

- Replaces manual null checks with optional chaining (`?.`) for a more modern and streamlined approach.
- Removes a redundant `undefined` check for tags.
- Simplifies prop destructuring for better clarity.