### PR TITLE
refactor: Centralize Post Fetching to Exclude Drafts

### DIFF
--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -4,7 +4,7 @@
 
 import { SITE } from "@config";
 import type { PaginateFunction } from "astro";
-import { getCollection } from "astro:content";
+import { getPosts } from "@utils/getPosts";
 import Posts from "@layouts/Posts.astro";
 // import Pagination from "@components/Astro/Pagination.astro";
 
@@ -13,9 +13,8 @@ export async function getStaticPaths({
 }: {
   paginate: PaginateFunction;
 }) {
-  const posts = await getCollection("blog");
-  const filteredPosts = posts.filter(post => import.meta.env.DEV || !post.data.isDraft);
-  return paginate(filteredPosts, {
+  const posts = await getPosts();
+  return paginate(posts, {
     pageSize: SITE.postsPerPage,
   });
 }

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,11 +1,10 @@
 ---
-import { getCollection } from "astro:content";
+import { getPosts } from "@utils/getPosts";
 import Post from "@layouts/Post.astro";
 
 export async function getStaticPaths() {
-	const posts = await getCollection("blog");
-	const filteredPosts = posts.filter(post => import.meta.env.DEV || !post.data.isDraft);
-	return filteredPosts.map((post) => ({
+	const posts = await getPosts();
+	return posts.map((post) => ({
 		params: { slug: post.id },
 		props: {
 			postId: post.id,

--- a/src/pages/feed.atom.js
+++ b/src/pages/feed.atom.js
@@ -1,20 +1,12 @@
 // This file generates the Atom feed for your blog.
-import { getCollection } from "astro:content";
+import { getPosts } from "@utils/getPosts";
 import { SITE } from "@config";
 import { COLLECTION_NAMES_LIST } from "../alkaline.config";
 
 export async function GET(context) {
-	const allPosts = await Promise.all(
-		COLLECTION_NAMES_LIST.map(async (collection) => {
-			const posts = await getCollection(collection);
-			return posts.map((post) => ({ ...post, collection }));
-		}),
-	);
+	const allPosts = await getPosts(COLLECTION_NAMES_LIST);
 
-	const sortedPosts = allPosts
-		.flat()
-		.filter((post) => !post.data?.isDraft)
-		.sort(
+	const sortedPosts = allPosts.sort(
 			(a, b) =>
 				new Date(b.data?.pubDatetime).valueOf() -
 				new Date(a.data?.pubDatetime).valueOf(),

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,11 @@
 ---
 import Layout from "@layouts/Layout.astro";
 import PageHeader from "@components/Astro/PageHeader.astro";
-import { getCollection, type CollectionEntry } from "astro:content";
+import { getPosts } from "@utils/getPosts";
 import ClickableCard from "@components/Astro/ClickableCard.astro";
 
 // Fetch and sort the first 3 blog posts
-const posts: CollectionEntry<'blog'>[] = (await getCollection("blog"))
+const posts = (await getPosts())
   .sort((a, b) => b.data.pubDatetime.valueOf() - a.data.pubDatetime.valueOf())
   .slice(0, 3);
 ---

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,21 +1,14 @@
 // Do not touch this file: This file generates the RSS feed for your blog. It pulls in all posts from the collections specified in COLLECTION_NAMES_LIST and formats them into an RSS feed.
 
 import rss from "@astrojs/rss";
-import { getCollection } from "astro:content";
+import { getPosts } from "@utils/getPosts";
 import { SITE, BLOG } from "@config";
 import { COLLECTION_NAMES_LIST } from "../alkaline.config";
 
 export async function GET(context) {
-	const allPosts = await Promise.all(
-		COLLECTION_NAMES_LIST.map(async (collection) => {
-			const posts = await getCollection(collection);
-			return posts.map((post) => ({ ...post, collection }));
-		})
-	);
+	const allPosts = await getPosts(COLLECTION_NAMES_LIST);
 
 	const items = allPosts
-		.flat()
-		.filter((post) => !post.data?.draft)
 		.sort(
 			(a, b) =>
 				new Date(a.data?.pubDatetime || 0).valueOf() -

--- a/src/pages/tags/[tag]/[...page].astro
+++ b/src/pages/tags/[tag]/[...page].astro
@@ -3,40 +3,16 @@
 
 import { SITE, COLLECTION_NAMES_LIST } from "../../../alkaline.config";
 import type { PaginateFunction } from "astro";
-import type { ContentEntryMap } from "astro:content";
-
-import { getCollection } from "astro:content";
+import { getPosts } from "@utils/getPosts";
 import Posts from "@layouts/Posts.astro";
 
-type Post = {
-  data: {
-    tags?: string[];
-  };
-};
+export async function getStaticPaths({ paginate }: { paginate: PaginateFunction }) {
+  const posts = await getPosts(COLLECTION_NAMES_LIST);
 
-export async function getStaticPaths({
-  paginate,
-}: {
-  paginate: PaginateFunction;
-}) {
-  const posts: Post[] = (
-    await Promise.all(
-      COLLECTION_NAMES_LIST.map(
-        async (collection) =>
-          await getCollection(collection as keyof ContentEntryMap)
-      )
-    )
-  ).flat();
-
-  const uniqueTags = [
-    ...new Set(posts.flatMap((post) => post.data.tags ?? [])),
-  ];
+  const uniqueTags = [...new Set(posts.flatMap((post) => post.data.tags ?? []))];
 
   return uniqueTags.flatMap((tag) => {
-    if (tag === undefined) return [];
-    const filteredPosts = posts.filter(
-      (post) => post.data.tags && post.data.tags.includes(tag)
-    );
+    const filteredPosts = posts.filter((post) => post.data.tags?.includes(tag));
     return paginate(filteredPosts, {
       params: { tag },
       pageSize: SITE.postsPerPage,
@@ -45,9 +21,8 @@ export async function getStaticPaths({
   });
 }
 
-const { page } = Astro.props;
-const { tag } = Astro.params ?? {};
-const posts = page?.data ?? [];
+const { page, tag } = Astro.props;
+const posts = page.data;
 ---
 
 <Posts

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,13 +1,11 @@
 ---
 import { COLLECTION_NAMES_LIST } from "src/alkaline.config";
-import { getCollection } from "astro:content";
+import { getPosts } from "@utils/getPosts";
 import Layout from "@layouts/Layout.astro";
 import TagCloud from "@components/Astro/TagCloud.astro";
 import Heading from "@components/Astro/Heading.astro";
 // Get all entries from all collections
-const allEntries = await Promise.all(
-	COLLECTION_NAMES_LIST.map((collection) => getCollection(collection))
-);
+const allEntries = await getPosts(COLLECTION_NAMES_LIST);
 
 // Flatten the array and extract tags
 const allTags = allEntries.flat().flatMap((entry) => entry.data.tags || []);

--- a/src/utils/getPosts.ts
+++ b/src/utils/getPosts.ts
@@ -1,0 +1,12 @@
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+export async function getPosts(collections: string[] = ['blog']): Promise<any[]> {
+  const allPosts = await Promise.all(
+    collections.map(async (collection) => {
+      const posts = await getCollection(collection as any);
+      const filteredPosts = posts.filter(post => import.meta.env.PROD ? !post.data.draft : true);
+      return filteredPosts;
+    })
+  );
+  return allPosts.flat();
+}


### PR DESCRIPTION
This pull request introduces a new utility function to centralize the logic for fetching and filtering posts. The primary goal is to prevent posts marked as `draft: true` in their frontmatter from being processed or appearing anywhere on the production site.

Previously, draft filtering was handled inconsistently across different pages, leading to draft posts appearing in tag clouds, RSS feeds, and other site areas. This change ensures that draft posts are filtered at the data source, providing a consistent and reliable experience.